### PR TITLE
Adds authentication to the schema

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -15,6 +15,10 @@ tags:
   - name: license
     description: Everything regarding licenses.
 
+servers:
+  - url: https://public-api.wordpress.com/wpcom/v2/jetpack-licensing/
+    description: WordPress API
+
 paths:
   /license:
     get:
@@ -30,7 +34,7 @@ paths:
           schema:
             $ref: '#/components/schemas/LicenseKey'
       security:
-        - partner_token: []
+        - ApiKeyAuth: []
       responses:
         '200':
           description: OK. Response body contains the license.
@@ -49,8 +53,6 @@ paths:
         - license
       summary: Issue a new license.
       operationId: issueLicense
-      security:
-        - partner_token: []
       requestBody:
         content:
           application/json:
@@ -69,6 +71,8 @@ paths:
                     - 'jetpack-backup-realtime'
                     - 'jetpack-scan'
                     - 'jetpack-anti-spam'
+      security:
+        - ApiKeyAuth: []
       responses:
         '200':
           description: OK. Response body contains the newly issued license.
@@ -95,7 +99,7 @@ paths:
           schema:
             $ref: '#/components/schemas/LicenseKey'
       security:
-        - partner_token: []
+        - ApiKeyAuth: []
       responses:
         '200':
           description: OK. Response body contains the license that was revoked.
@@ -115,7 +119,7 @@ paths:
       summary: Get all the available product families and their products.
       operationId: getProductFamilies
       security:
-        - partner_token: []
+        - ApiKeyAuth: []
       responses:
         '200':
           description: OK. Response body contains product families.
@@ -233,7 +237,8 @@ components:
           $ref: '#/components/headers/X-Jetpack-Request-Id'
 
   securitySchemes:
-    partner_token:
-      type: http
-      description: Generate a bearer token via https://public-api.wordpress.com/oauth2/token
-      scheme: bearer
+    ApiKeyAuth:
+      name: Authorization
+      type: apiKey
+      in: header
+      description: A token will be provided to you when you register as a partner.


### PR DESCRIPTION
Ideally we'd be able to use the "bearer" authentication method but for the life of me I couldn't get it to run in SwaggerHub. 
As an alternative, what's proposed in this commit does work but it has the downside of not being super obvious on how to configure it.

To try this out, go to SwaggerHub and paste the schema. On the right panel, click on the Authorize button:

<img width="664" alt="Screen Shot 2020-10-29 at 15 48 04" src="https://user-images.githubusercontent.com/348248/97630935-41b99100-19fe-11eb-86c0-0afb240fe591.png">

A modal window pops up:

<img width="651" alt="Screen Shot 2020-10-29 at 15 48 14" src="https://user-images.githubusercontent.com/348248/97630984-526a0700-19fe-11eb-942a-4b50b7b9e1f1.png">

The tricky part is that in the `value` input field you have to enter exactly what the API is expecting for the Authorization bearer, that is, `Bearer` + `<space>` + `<YOUR_API_TOKEN>`. Entering just the token won't work. 

For example, If your token is XYZ then you'd enter `Bearer XYZ`.

After doing this, you will be able to execute all the endpoint on to the live API.