### PR TITLE
Rename key to license_key

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -156,7 +156,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/LicenseId'
-        key:
+        license_key:
           $ref: '#/components/schemas/LicenseKey'
         issued_at:
           type: string


### PR DESCRIPTION
This PR renames `key` to `license_key` so that it matches the output of the API.