### PR TITLE
Remove 403 response from /product-families enpoint in spec as the endpoint requires no auth

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -132,8 +132,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProductFamily'
-        '403':
-          $ref: '#/components/responses/InvalidRequest'
   /partners:
     get:
       tags:


### PR DESCRIPTION
The endpoint no longer requires authentication and can therefore not return a 403.

https://app.asana.com/0/1187494150150258/1199390841749029